### PR TITLE
[8.0] Add survey_partner_tag_share module

### DIFF
--- a/survey_partner_tag_share/README.rst
+++ b/survey_partner_tag_share/README.rst
@@ -1,0 +1,68 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Survey Partner Tag Share
+========================
+
+This module was written to extend the functionality of sharing a survey. It
+allows the user to send a private mail to all the partners associated to a
+given tag.
+
+
+Usage
+=====
+
+To use this module, you need to:
+
+* Create a survey
+* Give a tag to some of your partners
+* Go on your survey page, share and invite
+* Choose a method which send emails
+* Add your tag to recipients
+* All the partners who have this tag will be added in the recipients field, thus
+will receive an email
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/200/8.0
+
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/survey/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/survey/issues/new?body=module:%20survey_partner_tag_share%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Agathe Mollé <agathe.molle@savoirfairelinux.com>
+* Bruno Joliveau <bruno.joliveau@savoirfairelinux.com>
+* Mathieu Boldireff <mathieu.boldireff@savoirfairelinux.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+

--- a/survey_partner_tag_share/README.rst
+++ b/survey_partner_tag_share/README.rst
@@ -1,13 +1,14 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License: AGPL-3
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+========================
 Survey Partner Tag Share
 ========================
 
-This module was written to extend the functionality of sharing a survey. It
+This module extends the functionality of sharing a survey . It
 allows the user to send a private mail to all the partners associated to a
 given tag.
-
 
 Usage
 =====
@@ -17,7 +18,7 @@ To use this module, you need to:
 * Create a survey
 * Give a tag to some of your partners
 * Go on your survey page, share and invite
-* Choose a method which send emails
+* Select the method to send emails
 * Add your tag to recipients
 * All the partners who have this tag will be added in the recipients field, thus
 will receive an email
@@ -26,23 +27,21 @@ will receive an email
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/200/8.0
 
-
-For further information, please visit:
-
-* https://www.odoo.com/forum/help-1
-
-
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/survey/issues>`_.
-In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/survey/issues/new?body=module:%20survey_partner_tag_share%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
-
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/survey/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------
@@ -64,5 +63,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
-
+To contribute to this module, please visit https://odoo-community.org.

--- a/survey_partner_tag_share/__init__.py
+++ b/survey_partner_tag_share/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from . import wizard

--- a/survey_partner_tag_share/__openerp__.py
+++ b/survey_partner_tag_share/__openerp__.py
@@ -1,32 +1,13 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Odoo, Open Source Management Solution
-#    This module copyright (C) 2015 Savoir-faire Linux
-#    (<http://www.savoirfairelinux.com>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Survey Partner Tag Share',
-    'version': '0.1',
+    'version': '8.0.1.0.0',
     'category': 'Marketing',
     'summary': 'Share a survey to all the partners that have a given tag',
     'author': 'Savoir-faire Linux, Odoo Community Association (OCA)',
-    'maintainer': 'Savoir-faire Linux',
-    'website': 'http://www.savoirfairelinux.com',
+    'website': 'https://odoo-community.org/',
     'license': 'AGPL-3',
     'depends': [
         'survey',

--- a/survey_partner_tag_share/__openerp__.py
+++ b/survey_partner_tag_share/__openerp__.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Survey Partner Tag Share',
+    'version': '0.1',
+    'category': 'Marketing',
+    'summary': 'Share a survey to all the partners that have a given tag',
+    'author': 'Savoir-faire Linux, Odoo Community Association (OCA)',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'depends': [
+        'survey',
+    ],
+    'data': [
+        'wizard/survey_email_compose_message.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/survey_partner_tag_share/i18n/fr.po
+++ b/survey_partner_tag_share/i18n/fr.po
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* survey_partner_tag_share
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-28 17:15+0000\n"
+"PO-Revision-Date: 2015-08-28 13:19-0500\n"
+"Last-Translator: Agathe Mollé <agathe.molle@savoirfairelinux.com>\n"
+"Language-Team: Savoir-faire Linux <support@savoirfairelinux.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.5.4\n"
+"Language: fr\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. module: survey_partner_tag_share
+#: view:survey.mail.compose.message:survey_partner_tag_share.survey_email_compose_message
+msgid "Add list of existing contacts..."
+msgstr "Ajouter une liste de contacts existants..."
+
+#. module: survey_partner_tag_share
+#: view:survey.mail.compose.message:survey_partner_tag_share.survey_email_compose_message
+msgid "Add list of existing tags..."
+msgstr "Ajouter une liste d'étiquettes existantes..."
+
+#. module: survey_partner_tag_share
+#: field:survey.mail.compose.message,partners_manual:0
+msgid "Add these partners to recipients"
+msgstr "Ajouter ces partenaires aux destinataires"
+
+#. module: survey_partner_tag_share
+#: field:survey.mail.compose.message,tags:0
+msgid "Add these tags to recipients"
+msgstr "Ajouter ces étiquettes aux destinataires"
+
+#. module: survey_partner_tag_share
+#: model:ir.model,name:survey_partner_tag_share.model_survey_mail_compose_message
+msgid "Email composition wizard for Survey"
+msgstr "Assistant de composition de courriels pour les sondages"

--- a/survey_partner_tag_share/i18n/survey_partner_tag_share.pot
+++ b/survey_partner_tag_share/i18n/survey_partner_tag_share.pot
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* survey_partner_tag_share
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-28 17:15+0000\n"
+"PO-Revision-Date: 2015-08-28 17:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: survey_partner_tag_share
+#: view:survey.mail.compose.message:survey_partner_tag_share.survey_email_compose_message
+msgid "Add list of existing contacts..."
+msgstr ""
+
+#. module: survey_partner_tag_share
+#: view:survey.mail.compose.message:survey_partner_tag_share.survey_email_compose_message
+msgid "Add list of existing tags..."
+msgstr ""
+
+#. module: survey_partner_tag_share
+#: field:survey.mail.compose.message,partners_manual:0
+msgid "Add these partners to recipients"
+msgstr ""
+
+#. module: survey_partner_tag_share
+#: field:survey.mail.compose.message,tags:0
+msgid "Add these tags to recipients"
+msgstr ""
+
+#. module: survey_partner_tag_share
+#: model:ir.model,name:survey_partner_tag_share.model_survey_mail_compose_message
+msgid "Email composition wizard for Survey"
+msgstr ""
+

--- a/survey_partner_tag_share/tests/__init__.py
+++ b/survey_partner_tag_share/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from . import test_survey_email_compose_message

--- a/survey_partner_tag_share/tests/test_survey_email_compose_message.py
+++ b/survey_partner_tag_share/tests/test_survey_email_compose_message.py
@@ -1,0 +1,62 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from openerp.tests import TransactionCase
+
+
+class TestSurveyEmailComposeMessage(TransactionCase):
+
+    def setUp(self):
+
+        super(TestSurveyEmailComposeMessage, self).setUp()
+
+        self.PartnerObj = self.env['res.partner']
+        self.PartnerCategoryObj = self.env['res.partner.category']
+        self.SurveyObj = self.env['survey.survey']
+        self.SurveyPageObj = self.env['survey.page']
+        self.SurveyQuestionObj = self.env['survey.question']
+        self.SurveyLabelObj = self.env['survey.label']
+        self.WizardObj = self.env['survey.mail.compose.message']
+
+        self.partners = [
+            self.PartnerObj.create({
+                'name': record[0],
+                'email': record[1],
+            }) for record in [
+                ('test0', 'test0@test_example.com'),
+                ('test1', 'test1@test_example.com'),
+                ('test2', 'test2@test_example.com'),
+                ('test3', 'test3@test_example.com'),
+                ('test4', 'test4@test_example.com'),
+                ('test5', 'test5@test_example.com'),
+                ('test6', 'test6@test_example.com'),
+            ]
+        ]
+
+        self.tag = self.PartnerCategoryObj.create({
+            'name': 'Test tag',
+            'partner_ids': [(6, 0, [self.partners[i].id for i in range(4)])]
+        })
+
+        self.survey = self.SurveyObj.create({
+            'title': 'Survey Test',
+        })
+
+        self.wizard = self.WizardObj.create({
+            'survey_id': self.survey.id,
+            'public': 'email_private',
+            'tags': [(6, 0, [self.tag.id])],
+            'partners_manual': [(6, 0,
+                                 [self.partners[i].id for i in range(4, 6)])]
+        })
+
+    def test_get_recipients(self):
+        """
+        Make sure partner_ids field is computed properly
+        """
+        self.assertEquals(
+            [p.id for p in self.wizard.partner_ids],
+            [self.partners[i].id for i in range(6)],
+        )

--- a/survey_partner_tag_share/wizard/__init__.py
+++ b/survey_partner_tag_share/wizard/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from . import survey_email_compose_message

--- a/survey_partner_tag_share/wizard/survey_email_compose_message.py
+++ b/survey_partner_tag_share/wizard/survey_email_compose_message.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from openerp import api, fields, models
+
+
+class SurveyMailComposeMessage(models.TransientModel):
+    _inherit = 'survey.mail.compose.message'
+
+    tags = fields.Many2many(
+        string='Add these tags to recipients',
+        comodel_name='res.partner.category',
+        relation='survey_mail_compose_message_res_partner_tag_rel',
+        column1='wizard_id',
+        column2='partner_tag_id',
+    )
+    partners_manual = fields.Many2many(
+        string='Add these partners to recipients',
+        comodel_name='res.partner',
+        relation='survey_mail_compose_message_res_partner_manual_rel',
+        column1='wizard_id',
+        column2='partner_manual_id',
+    )
+    partner_ids = fields.Many2many(
+        string='Recipients',
+        readonly=True,
+        compute='get_recipients'
+    )
+
+    @api.depends('tags', 'partners_manual')
+    def get_recipients(self):
+        """
+        Populate the partner_ids field (Recipients) with all the partners
+        added manually (in partners_manual) and the partners who have the
+        tags chosen (in tags).
+        Duplicates are avoided (we don't want partners to receive twice the
+        same email because they have 2 tags interesting for us).
+        This partner list is sorted by display_name.
+        """
+        self.partner_ids = self.partners_manual
+        for tag in self.tags:
+            self.partner_ids |= tag.partner_ids
+        self.partner_ids = self.partner_ids.sorted(
+            key=lambda p: p.display_name
+        )

--- a/survey_partner_tag_share/wizard/survey_email_compose_message.xml
+++ b/survey_partner_tag_share/wizard/survey_email_compose_message.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="survey_email_compose_message">
+      <field name="inherit_id" ref="survey.survey_email_compose_message" />
+      <field name="model">survey.mail.compose.message</field>
+      <field name="arch" type="xml">
+
+        <xpath expr="//field[@name='partner_ids']/.." position="before">
+          <group col="2">
+            <field invisible="context.get('survey_resent_token')" name="partners_manual" widget="many2many_tags_email" placeholder="Add list of existing contacts..." context="{'force_email':True, 'show_email':True}" />
+            <field invisible="context.get('survey_resent_token')" name="tags" widget="many2many_tags_email" placeholder="Add list of existing tags..." context="{'force_email':True, 'show_email':True}" />
+          </group>
+        </xpath>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
This module allows to share a survey to all the partners associated to a given tag.

The recipients are now a readonly field.
If you add a partner, it will be added to the recipients.
If you add a tag, all the partners who have this tag will be added to the recipients.

The recipients field doesn't contain any duplicate, and it is sorted by display_name.
