### PR TITLE
[13.0] [FIX] survey_formio: fix multiple choice answers

### DIFF
--- a/survey_formio/models/survey.py
+++ b/survey_formio/models/survey.py
@@ -86,6 +86,9 @@ class SurveySurvey(models.Model):
         }}
         Odoo expects the following format:
         {"question_id_answer_id": "answer_id"}
+        Form.io returns all the answers with true or false but odoo doesn't
+        distinguish them like that. If the answer isn't selected, it shouldn't appear
+        in the dictionnary containing the answers.
 
         Returns a dictionnary with the correct format.
 
@@ -94,6 +97,9 @@ class SurveySurvey(models.Model):
         multiple_choice_answers_dict: dict given by form.io for a multiple choice question
         """
         answers_dict = {}
+        multiple_choice_answers_dict = {
+            key: value for (key, value) in multiple_choice_answers_dict.items() if value
+        }
         for answer in multiple_choice_answers_dict.keys():
             answers_dict[question_id + "_" + answer[1:]] = answer[1:]
         return answers_dict

--- a/survey_formio/tests/test_survey_formio.py
+++ b/survey_formio/tests/test_survey_formio.py
@@ -241,7 +241,7 @@ class TestSurveyFormIo(common.SavepointCase):
         user_input = self.survey_public.user_input_ids[0]
 
         # 7 questions answered but for the multiple choice there's a line per answer
-        self.assertEqual(len(user_input.user_input_line_ids), 9)
+        self.assertEqual(len(user_input.user_input_line_ids), 8)
         self.assertEqual(
             user_input.user_input_line_ids.filtered(
                 lambda uil: uil.answer_type == "free_text"
@@ -262,6 +262,27 @@ class TestSurveyFormIo(common.SavepointCase):
                 lambda uil: uil.question_id == simple_choice_question
             ).value_suggested,
             simple_choice_question.labels_ids[1],
+        )
+
+        multiple_choice_question = self.survey_public.question_ids.filtered(
+            lambda q: q.question_type == "multiple_choice"
+        )
+        self.assertEqual(
+            len(
+                user_input.user_input_line_ids.filtered(
+                    lambda uil: uil.question_id == multiple_choice_question
+                )
+            ),
+            2,
+        )
+        self.assertEqual(
+            len(
+                user_input.user_input_line_ids.filtered(
+                    lambda uil: uil.question_id == multiple_choice_question
+                    and uil.value_suggested == multiple_choice_question.labels_ids[2]
+                )
+            ),
+            0,
         )
 
         self.assertEqual(self.survey_private.answer_count, 0)
@@ -320,7 +341,7 @@ class TestSurveyFormIo(common.SavepointCase):
         user_input = self.survey_public.user_input_ids[0]
 
         # 7 questions answered but for the multiple choice there's a line per answer
-        self.assertEqual(len(user_input.user_input_line_ids), 9)
+        self.assertEqual(len(user_input.user_input_line_ids), 8)
         self.assertEqual(
             user_input.user_input_line_ids.filtered(
                 lambda uil: uil.answer_type == "free_text"


### PR DESCRIPTION
The dictionnary with the answer for a multiple choice question should only contain true answers.