### PR TITLE
[15.0][FIX] survey_resource_booking: adapt to partner refactor

### DIFF
--- a/survey_resource_booking/tests/test_invite.py
+++ b/survey_resource_booking/tests/test_invite.py
@@ -32,7 +32,7 @@ class SurveyInvitationCase(TransactionCase):
         # Make sure RB gets surveyed as expected
         booking_f = Form(self.env["resource.booking"])
         booking_f.type_id = self.rbt
-        booking_f.partner_id = self.partner
+        booking_f.partner_ids.add(self.partner)
         booking_f.start = datetime(2021, 3, 1, 8)
         booking = booking_f.save()
         self.assertEqual(booking.state, "scheduled")


### PR DESCRIPTION
We need to adapt tests to https://github.com/OCA/calendar/pull/110

cc @Tecnativa TT45338

please review @carolinafernandez-tecnativa @pedrobaeza 