### PR TITLE
[fix] survey_question_type_five_star: remove reference to style from other module (nps)

### DIFF
--- a/survey_question_type_five_star/static/src/scss/parameters.scss
+++ b/survey_question_type_five_star/static/src/scss/parameters.scss
@@ -1,2 +1,3 @@
 /* survey.scss parameters */
 $star-widget-color: #deb217;
+$star-widget-label-color: #0a0a0a;

--- a/survey_question_type_five_star/static/src/scss/survey.scss
+++ b/survey_question_type_five_star/static/src/scss/survey.scss
@@ -20,5 +20,5 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
     white-space: nowrap;
     cursor: pointer;
     font-size: 30px;
-    color: $nps-widget-color;
+    color: $star-widget-label-color;
 }


### PR DESCRIPTION
removed reference to $nps-widget-color; which caused an error whenever the survey is viewed (survey still worked). This fix removes the error