### PR TITLE
[14.0][FIX] survey_question_type_binary: Participant answer

### DIFF
--- a/survey_question_type_binary/models/survey_user_input.py
+++ b/survey_question_type_binary/models/survey_user_input.py
@@ -17,12 +17,15 @@ class SurveyUserInput(models.Model):
         if question.question_type in ("binary", "multi_binary"):
             if not isinstance(answer, (list, tuple)):
                 answer = [answer]
+            if not answer:
+                answer = [False]
             for answer_binary in answer:
                 old_answers = self._save_line_simple_answer(
                     question, old_answers, answer_binary
                 )
         else:
             super(SurveyUserInput, self).save_lines(question, answer, comment=comment)
+        return True
 
     def _get_line_answer_values(self, question, answer, answer_type):
         vals = super(SurveyUserInput, self)._get_line_answer_values(

--- a/survey_question_type_binary/tests/test_survey.py
+++ b/survey_question_type_binary/tests/test_survey.py
@@ -83,7 +83,7 @@ class TestSurvey(common.SurveyCase):
                 {
                     "title": "Test Binary",
                     "page_id": self.page1.id,
-                    "question_type": "binary",
+                    "question_type": "multi_binary",
                     "allowed_filemimetypes": "image/png",
                     "max_filesize": 2097152,
                     "validation_required": True,


### PR DESCRIPTION
Partial backport of #121  
- Create a Skipped answer when the binary question is not filled

display_name stuff is not backported because not needed here