### PR TITLE
[16.0] survey_question_type_nps: Remove manual styles and align to su…

### DIFF
--- a/survey_question_type_nps/__manifest__.py
+++ b/survey_question_type_nps/__manifest__.py
@@ -15,7 +15,6 @@
     "assets": {
         "survey.survey_assets": [
             "survey_question_type_nps/static/src/js/survey.js",
-            "survey_question_type_nps/static/src/scss/parameters.scss",
             "survey_question_type_nps/static/src/scss/survey.scss",
         ],
     },

--- a/survey_question_type_nps/static/src/scss/parameters.scss
+++ b/survey_question_type_nps/static/src/scss/parameters.scss
@@ -1,3 +1,0 @@
-/* survey.scss parameters */
-$nps-widget-background-color: #fff;
-$nps-widget-color: #0a0a0a;

--- a/survey_question_type_nps/static/src/scss/survey.scss
+++ b/survey_question_type_nps/static/src/scss/survey.scss
@@ -1,51 +1,13 @@
 /* Copyright 2018 ACSONE SA/NV
 License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
-.nps_rate_widget {
-    margin-left: 10px;
-}
-.nps_rate_widget > input {
-    display: none;
-}
 .nps_rate_widget > label {
-    font: 20px Arial, sans-serif;
-
     width: 2em;
     height: 2em;
-    box-sizing: initial;
-
-    background: $nps-widget-background-color;
-    border: 0.15em solid $nps-widget-color;
-    color: $nps-widget-color;
-    text-align: center;
-    border-radius: 50%;
-
-    line-height: 2em;
-    box-sizing: content-box;
-
-    float: right;
-    cursor: pointer;
-    margin: 10px;
-
-    @include media-breakpoint-down(md) {
-        font: 16px Arial, sans-serif;
-
-        width: 1.5em;
-        height: 1.5em;
-        box-sizing: initial;
-        text-align: center;
-        border-radius: 50%;
-
-        line-height: 1.5em;
-        box-sizing: content-box;
-
-        float: right;
-        cursor: pointer;
-        margin: 3px;
-    }
 }
-.nps_rate > label:hover,
 .nps_rate_widget .checked {
-    color: $nps-widget-background-color;
-    background: $nps-widget-color;
+    @extend .o_survey_selected;
+    // Surveys do not import full bootstrap so we can't extend bg-primary and text-white
+    background-color: $primary;
+    color: $white;
 }

--- a/survey_question_type_nps/views/survey_template.xml
+++ b/survey_question_type_nps/views/survey_template.xml
@@ -47,43 +47,43 @@
             <div class="nps_rate nps_rate_widget">
                 <label
                     for="num10"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 10 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 10 else ''}"
                 >10</label>
                 <label
                     for="num9"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 9 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 9 else ''}"
                 >9</label>
                 <label
                     for="num8"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 8 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 8 else ''}"
                 >8</label>
                 <label
                     for="num7"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 7 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 7 else ''}"
                 >7</label>
                 <label
                     for="num6"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 6 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 6 else ''}"
                 >6</label>
                 <label
                     for="num5"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 5 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 5 else ''}"
                 >5</label>
                 <label
                     for="num4"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 4 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 4 else ''}"
                 >4</label>
                 <label
                     for="num3"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 3 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 3 else ''}"
                 >3</label>
                 <label
                     for="num2"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 2 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 2 else ''}"
                 >2</label>
                 <label
                     for="num1"
-                    t-attf-class="#{'checked' if answer_lines and answer_lines.value_numerical_box == 1 else ''}"
+                    t-attf-class="o_survey_choice_btn ms-3 me-3 mb-3 text-center rounded-circle lh-lg float-end #{'checked' if answer_lines and answer_lines.value_numerical_box == 1 else ''}"
                 >1</label>
                 <input
                     type="number"


### PR DESCRIPTION
…rvey theme

Removes unnecessary style that were hardcoded and aligns nps style to the style set by the main theme.
It also works in mobile wrapping in two rows (1-5, 6-10)


### Before
![before](https://github.com/user-attachments/assets/047452e3-a621-4327-a3b7-b9330738b000)
### After
![after](https://github.com/user-attachments/assets/7ca1f872-306f-49fe-9edf-d57ddbd530d7)
