### PR TITLE
[15.0][FIX] survey_certification_py3o: Change conditions to generate report + test

### DIFF
--- a/survey_certification_py3o/models/py3o_report.py
+++ b/survey_certification_py3o/models/py3o_report.py
@@ -9,6 +9,9 @@ class Py3oReport(models.TransientModel):
     _inherit = "py3o.report"
 
     def _get_template_fallback(self, model_instance):
-        if model_instance._name == "survey.survey":
+        if (
+            model_instance._name == "survey.user_input"
+            and model_instance.py3o_template_id
+        ):
             return b64decode(model_instance.py3o_template_id.py3o_template_data)
         return super()._get_template_fallback(model_instance)

--- a/survey_certification_py3o/tests/test_survey_certification_py3o.py
+++ b/survey_certification_py3o/tests/test_survey_certification_py3o.py
@@ -1,8 +1,33 @@
+import io
+import os
+import zipfile
+from base64 import b64encode
+
+from odoo.modules.module import get_module_resource
+
 from odoo.addons.survey.tests.common import TestSurveyCommon
 
 
 class TestCertificationPy3o(TestSurveyCommon):
     def test_certification_py3o(self):
+        demo_odt_path = get_module_resource(
+            "survey_certification_py3o", "demo", "demo_report_certification.odt"
+        )
+        self.assertTrue(os.path.isfile(demo_odt_path))
+        with open(demo_odt_path, "rb") as f:
+            odt_data = f.read()
+            try:
+                zipfile.ZipFile(io.BytesIO(odt_data)).testzip()
+            except zipfile.BadZipFile:
+                self.fail("El archivo .odt no es válido (no es un ZIP correcto)")
+
+        py3o_template = self.env["py3o.template"].create(
+            {
+                "name": "Demo Report Certification Template",
+                "py3o_template_data": b64encode(odt_data),
+                "filetype": "odt",
+            }
+        )
         test_certification = self.env["survey.survey"].create(
             {
                 "title": "Test Certification py3o",
@@ -18,6 +43,7 @@ class TestCertificationPy3o(TestSurveyCommon):
                 ).id,
                 "is_time_limited": True,
                 "time_limit": 10,
+                "py3o_template_id": py3o_template.id,
             }
         )
         q_01 = self._add_question(
@@ -55,3 +81,12 @@ class TestCertificationPy3o(TestSurveyCommon):
         self._add_answer_line(q_02, answer, q_02.suggested_answer_ids[2].id)
         answer.with_user(self.env.user).write({"state": "done"})
         answer._mark_done()
+        self.assertEqual(
+            answer.py3o_template_id.id, test_certification.py3o_template_id.id
+        )
+        report = self.env.ref(
+            "survey_certification_py3o.custom_certification_report"
+        ).with_user(self.env.uid)
+        pdf_data = report._render_py3o([answer.id], data={"report_type": "pdf"})[0]
+        self.assertTrue(pdf_data)
+        self.assertIsInstance(pdf_data, bytes)


### PR DESCRIPTION
Checking only the model can generate an error when there is no template defined, better to check if the template is defined too. The model that generates the report is actually survey.user_input

@tecnativa 

@victoralmau @carlos-lopez-tecnativa please review