### PR TITLE
[15.0][FIX] survey_sale_generation: use env.company instead of create_uid.ompany_id

### DIFF
--- a/survey_sale_generation/models/survey_user_input.py
+++ b/survey_sale_generation/models/survey_user_input.py
@@ -17,7 +17,7 @@ class SurveyUserInput(models.Model):
             "partner_id": self.partner_id.id or self.create_uid.partner_id.id,
             "origin": self.survey_id.title,
             "survey_user_input_id": self.id,
-            "company_id": self.create_uid.company_id.id,
+            "company_id": self.env.company.id,
             "team_id": self.survey_id.crm_team_id.id,
             "sale_order_template_id": sale_template.id,
             "user_id": (


### PR DESCRIPTION
When generating a quotation from a survey response, the sale order was being assigned to the company of the `create_uid`. This is incorrect in multi-company contexts, especially when the user has access to multiple companies and their default company (`company_id`) is not the active one.

Instead, this commit uses `self.env.company` to retrieve the currently active company from the context, which correctly reflects the company in which the user is operating when completing the survey.

This change ensures that the sale order is created in the company active in the user's session, avoiding multi-company integrity errors (e.g. trying to create a record in a company other than the one currently active).

<img width="274" height="153" alt="image" src="https://github.com/user-attachments/assets/5f874dbf-8362-49e5-8ecf-011e6a15c979" />

@Tecnativa TT57057

@pedrobaeza @victoralmau please review