### PR TITLE
[15.0][IMP-FIX] survey_multi_company: force survey company in context to avoid multi-company issues

### DIFF
--- a/survey_multi_company/__init__.py
+++ b/survey_multi_company/__init__.py
@@ -1,1 +1,2 @@
+from . import controllers
 from . import models

--- a/survey_multi_company/controllers/__init__.py
+++ b/survey_multi_company/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/survey_multi_company/controllers/main.py
+++ b/survey_multi_company/controllers/main.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.survey.controllers.main import Survey
+
+
+class SurveyMultiCompany(Survey):
+    def _get_access_data(self, survey_token, answer_token, ensure_token=True):
+        # Web survey access in multi-company environments may lack an explicit active
+        # company, causing request.env.company to default to the user's default company
+        # or the first allowed one. This can lead to incorrect rule evaluation, access
+        # errors, or company-specific logic failures. To ensure consistent behavior, we
+        # explicitly switch to the company assigned to the survey.
+        data = super()._get_access_data(
+            survey_token, answer_token, ensure_token=ensure_token
+        )
+        survey_sudo = data.get("survey_sudo")
+        if survey_sudo and survey_sudo.company_id:
+            data["survey_sudo"] = survey_sudo.with_company(survey_sudo.company_id)
+            if data.get("answer_sudo"):
+                data["answer_sudo"] = data["answer_sudo"].with_company(
+                    survey_sudo.company_id
+                )
+        return data


### PR DESCRIPTION
In multi-company environments, survey requests made through web routes are executed without a specific company_id in the context. As a result, request.env.company defaults to the user's default company or the first in allowed_company_ids, which may lead to access errors, incorrect rule evaluations, or unexpected behavior.
To ensure that the survey logic runs under the correct company context, allowed_company_ids is explicitly set to the company assigned to the survey.

<img width="2483" height="922" alt="image" src="https://github.com/user-attachments/assets/70e21528-5f82-42c7-af85-a7d390b4b383" />

<img width="777" height="315" alt="image" src="https://github.com/user-attachments/assets/8edc53ad-720d-4630-8d61-76390938d518" />

@pedrobaeza @victoralmau please review