### PR TITLE
[17.0][FIX] survey_crm_generation: use env.company instead of create_uid.company_id

### DIFF
--- a/survey_crm_generation/models/survey_user_input.py
+++ b/survey_crm_generation/models/survey_user_input.py
@@ -15,7 +15,7 @@ class SurveyUserInput(models.Model):
             "partner_id": self.partner_id.id,
             "user_id": self.survey_id.crm_team_id.user_id.id,
             "team_id": self.survey_id.crm_team_id.id,
-            "company_id": self.create_uid.company_id.id,
+            "company_id": self.env.company.id,
             "survey_user_input_id": self.id,
             "description": self._prepare_lead_description(),
         }


### PR DESCRIPTION
When generating a oportunity from a survey response, the oportunity was being assigned to the company of the create_uid. This is incorrect in multi-company contexts, especially when the user has access to multiple companies and their default company (company_id) is not the active one.

Instead, this commit uses self.env.company to retrieve the currently active company from the context, which correctly reflects the company in which the user is operating when completing the survey.

This change ensures that the oportunity is created in the company active in the user's session, avoiding multi-company integrity errors (e.g. trying to create a record in a company other than the one currently active).

@Tecnativa TT57860

@pedrobaeza @victoralmau please review