### PR TITLE
[17.0][FIX] survey_skip_start: Cannot skip start in session survey

### DIFF
--- a/survey_skip_start/README.rst
+++ b/survey_skip_start/README.rst
@@ -60,7 +60,7 @@ be leaded directly to the form.
 Known issues / Roadmap
 ======================
 
-- For the moment, it only works with one page layouts.
+-  For the moment, it only works with one page layouts.
 
 Bug Tracker
 ===========
@@ -83,9 +83,9 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__
+-  `Tecnativa <https://www.tecnativa.com>`__
 
-  - David Vidal
+   -  David Vidal
 
 Maintainers
 -----------
@@ -100,13 +100,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-chienandalu| image:: https://github.com/chienandalu.png?size=40px
-    :target: https://github.com/chienandalu
-    :alt: chienandalu
+.. |maintainer-pilarvargas-tecnativa| image:: https://github.com/pilarvargas-tecnativa.png?size=40px
+    :target: https://github.com/pilarvargas-tecnativa
+    :alt: pilarvargas-tecnativa
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-chienandalu| 
+|maintainer-pilarvargas-tecnativa| 
 
 This module is part of the `OCA/survey <https://github.com/OCA/survey/tree/17.0/survey_skip_start>`_ project on GitHub.
 

--- a/survey_skip_start/__manifest__.py
+++ b/survey_skip_start/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Marketing/Survey",
     "website": "https://github.com/OCA/survey",
     "author": "Tecnativa, Odoo Community Association (OCA)",
-    "maintainers": ["chienandalu"],
+    "maintainers": ["pilarvargas-tecnativa"],
     "license": "AGPL-3",
     "depends": ["survey"],
     "data": [

--- a/survey_skip_start/models/survey_survey.py
+++ b/survey_skip_start/models/survey_survey.py
@@ -15,5 +15,7 @@ class SurveySurvey(models.Model):
         """The survey template checks the state of the inputs to show the start screen
         or not. Setting the state we go directly to the form"""
         inputs = super()._create_answer(*args, **additional_vals)
-        inputs.filtered("survey_id.skip_start").state = "in_progress"
+        inputs.filtered(
+            lambda input: input.survey_id.skip_start and not input.is_session_answer
+        ).state = "in_progress"
         return inputs

--- a/survey_skip_start/static/description/index.html
+++ b/survey_skip_start/static/description/index.html
@@ -448,7 +448,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/chienandalu"><img alt="chienandalu" src="https://github.com/chienandalu.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/pilarvargas-tecnativa"><img alt="pilarvargas-tecnativa" src="https://github.com/pilarvargas-tecnativa.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/survey/tree/17.0/survey_skip_start">OCA/survey</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
When a survey in which it has been established that the beginning of the survey should be skipped is created, a pagination error occurs because in sessions this start/waiting page cannot be skipped at the beginning of the session.

<img width="1437" height="722" alt="image" src="https://github.com/user-attachments/assets/f51dd2f2-0f1c-43d6-a331-221e0bb1c29b" />

@Tecnativa TT58491

@chienandalu @pedrobaeza @victoralmau please review

