### PR TITLE
[16.0][FIX] survey_certification_branding

### DIFF
--- a/survey_certification_branding/__manifest__.py
+++ b/survey_certification_branding/__manifest__.py
@@ -16,4 +16,9 @@
         "views/survey_survey_views.xml",
         "report/survey_report_templates.xml",
     ],
+    "assets": {
+        "web.report_assets_common": [
+            "survey_certification_branding/static/src/scss/survey_reports.scss",
+        ],
+    },
 }

--- a/survey_certification_branding/models/survey_survey.py
+++ b/survey_certification_branding/models/survey_survey.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 class SurveySurvey(models.Model):
     _inherit = "survey.survey"
 
+    title = fields.Char(size=180)
     certification_company_name = fields.Char(
         "Certification - Company Name",
         help=(
@@ -15,6 +16,7 @@ class SurveySurvey(models.Model):
         ),
         compute="_compute_certification_branding_fields",
         store=True,
+        size=100,
         readonly=False,
     )
 

--- a/survey_certification_branding/readme/CONTRIBUTORS.md
+++ b/survey_certification_branding/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Rolando Pérez Rebollo <r.perez@binhex.cloud> (https://binhex.cloud)
+- Edilio Escalona Almira <e.escalona@binhex.cloud> (https://binhex.cloud)

--- a/survey_certification_branding/report/survey_report_templates.xml
+++ b/survey_certification_branding/report/survey_report_templates.xml
@@ -35,10 +35,10 @@
         </xpath>
         <xpath expr="//span[@t-field='user_input.env.company.logo']" position="after">
             <t t-else="">
-                <span
-                    class="certification-company-logo"
-                    t-field="user_input.survey_id.certification_logo_512"
-                    t-options="{'widget': 'image'}"
+                <img
+                    class="certification-company-logo certification-branding"
+                    t-att-src="image_data_uri(user_input.survey_id.certification_logo_512)"
+                    style="max-height: 100px;"
                     role="img"
                 />
             </t>
@@ -80,10 +80,10 @@
         </xpath>
         <xpath expr="//span[@t-field='user_input.env.company.logo']" position="after">
             <t t-else="">
-                <span
-                    class="certification-company-logo"
-                    t-field="user_input.survey_id.certification_logo_512"
-                    t-options="{'widget': 'image'}"
+                <img
+                    class="certification-company-logo certification-branding"
+                    t-att-src="image_data_uri(user_input.survey_id.certification_logo_512)"
+                    style="max-height: 100px;"
                     role="img"
                 />
             </t>

--- a/survey_certification_branding/static/src/scss/survey_reports.scss
+++ b/survey_certification_branding/static/src/scss/survey_reports.scss
@@ -1,0 +1,27 @@
+#o_survey_certification.certification-wrapper {
+    .certification {
+        .certification-bottom {
+            bottom: 0 !important;
+        }
+    }
+
+    // Modern Template
+    &.modern {
+        .certification {
+            .certification-top {
+                padding-bottom: 2mm !important;
+            }
+        }
+    }
+
+    &.classic {
+        .certification-bottom {
+            .certification-number {
+                bottom: 0 !important;
+            }
+            .certification-seal {
+                top: 45% !important;
+            }
+        }
+    }
+}

--- a/survey_certification_branding/tests/test_survey_certification_branding.py
+++ b/survey_certification_branding/tests/test_survey_certification_branding.py
@@ -25,10 +25,10 @@ class TestSurveyCertificationBranding(common.TestSurveyCommon):
         certification = user_input.survey_id
         if certification.certification:
             self.assertIn(self.certification_company_name, res)
-            self.assertIn("certification_logo_512", res)
+            self.assertIn("certification-branding", res)
         else:
             self.assertNotIn(self.certification_company_name, res)
-            self.assertNotIn("certification_logo_512", res)
+            self.assertNotIn("certification-branding", res)
 
     def test_branding_fields_flow_and_certification_report_rendering(self):
         with self.with_user("survey_user"):


### PR DESCRIPTION
@BinhexTeam

When a portal user registers and completes a certification, the following errors occur:

- When the text in the "Company Name" field in the "Certification Mark" section and the survey name are too long, they overlap with the date and image values ​​for the "Certification Mark." Therefore, limiting these to 100 and 180 characters, respectively, is recommended.
- The image configured in the "Certification Mark" section of the survey is not displayed.

This change request resolves both of these issues.

Survey title:
<img width="2238" height="228" alt="image" src="https://github.com/user-attachments/assets/47e51607-f7e7-46ad-b276-782706d87c54" />

Company name (Certification branding)
<img width="1330" height="256" alt="image" src="https://github.com/user-attachments/assets/567dccf3-3068-4cce-a187-9ade833722d7" />


[FIX] Before (Certification Modern)
<img width="2266" height="1530" alt="image" src="https://github.com/user-attachments/assets/803b1ddd-ac13-4eae-8fa7-d550657afd84" />

[FIX] Before (Certification Classic)
<img width="2250" height="1538" alt="image" src="https://github.com/user-attachments/assets/0a8d73eb-b0f4-4d47-9d36-e634bb0cdd78" />


After (Certification Modern)
<img width="2274" height="1542" alt="image" src="https://github.com/user-attachments/assets/71a0568a-dd45-4e83-8821-367692098ab7" />

After (Certification Classic)
<img width="2320" height="1538" alt="image" src="https://github.com/user-attachments/assets/f400547a-5719-4482-bae3-028fed1f4b5f" />
