### PR TITLE
[17.0][FIX] survey_sale_generation: Make the tour selector more resilient

### DIFF
--- a/survey_sale_generation/static/tests/survey_sale_generation_tour.esm.js
+++ b/survey_sale_generation/static/tests/survey_sale_generation_tour.esm.js
@@ -73,7 +73,7 @@ registry.category("web_tour.tours").add("test_survey_sale_generation", {
         },
         {
             content: "Thank you",
-            trigger: "h1:contains('Thank you!')",
+            trigger: "div.o_survey_finished",
         },
     ],
 });


### PR DESCRIPTION
If any module modifies the survey completion message, it may cause an error when searching for that text. To avoid this situation, a more resilient selector is added, searching for a specific class on the survey completion page.

@Tecnativa

@pedrobaeza @CarlosRoca13 please review