### PR TITLE
[19.0][FIX] survey_contact_generation: restore field to the view

### DIFF
--- a/survey_contact_generation/views/survey_survey_views.xml
+++ b/survey_contact_generation/views/survey_survey_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <group name="options" position="inside">
                 <group name="contact_options" string="Contact">
+                    <field name="generate_contact" />
                     <field
                         name="create_parent_contact"
                         invisible="not generate_contact"


### PR DESCRIPTION
Field `generate_contact` was drop from `survey_survey_view_form` during migration to 19.0

cc @Tecnativa 
ping @pedrobaeza @adasatorres-tecnativa

Found while reviewing https://github.com/OCA/survey/pull/255