### PR TITLE
[19.0][FIX] survey_answer_generation: compute_diff_with_origin crash on unanswered suggestion

### DIFF
--- a/survey_answer_generation/models/survey_user_input.py
+++ b/survey_answer_generation/models/survey_user_input.py
@@ -120,8 +120,8 @@ class SurveyUserInputLine(models.Model):
                 previous_value = str(line.origin_input_line[value] or "")
                 current_value = str(line[value] or "")
             else:
-                current_value = line.suggested_answer_id.value
-                previous_value = line.origin_input_line.suggested_answer_id.value
+                current_value = line.suggested_answer_id.value or ""
+                previous_value = line.origin_input_line.suggested_answer_id.value or ""
             if previous_value == current_value:
                 continue
             line.diff_with_origin = get_diff(


### PR DESCRIPTION
Follow-up to #259 

The else branch of `_compute_diff_with_origin` (suggestion answers) doesn't coerce the values, so when a choice question mapped between two chained surveys is answered in the first one and cleared in the second, `current_value` is `False` and `get_diff()` fails

<img width="861" height="357" alt="imagen" src="https://github.com/user-attachments/assets/cc8813eb-4579-4292-8e6d-47621285c0a8" />

@Tecnativa 
@pedrobaeza @adasatorres-tecnativa 